### PR TITLE
add version information in Put Action's output

### DIFF
--- a/credstash.py
+++ b/credstash.py
@@ -419,7 +419,7 @@ def putSecretAction(args, region, **session_params):
                      kms_key=args.key, region=region, table=args.table,
                      context=args.context, digest=args.digest, comment=args.comment,
                      **session_params):
-            print("{0} has been stored".format(args.credential))
+            print("{0}:{1} has been stored".format(args.credential, version))
     except KmsError as e:
         fatal(e)
     except botocore.exceptions.ClientError as e:

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import setup
 
 name = 'credstash'
-version = '1.15.0'
+version = '1.19.0'
 
 setup(
     name=name,


### PR DESCRIPTION
Use case: after a write, we want to get the version of the key.

Current solution: a credstash list has to be done in order to get the last version. The list is using a `scan` on the dynamodb, and scan is not recommended because it's consuming a lot of the read capacity. See official best practices : https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/bp-query-scan.html

During the write, the version is already computed, we just output it.

Example : 

```
credstash -t credential-store put -k alias/kms-credstash -a myKey aValue
myKey:0000000000000000042 has been stored
```